### PR TITLE
Ensure list view doesn't show unexpectedly

### DIFF
--- a/GooglePlacesAutocomplete.js
+++ b/GooglePlacesAutocomplete.js
@@ -130,7 +130,7 @@ export default class GooglePlacesAutocomplete extends Component {
   }
 
   componentWillReceiveProps(nextProps) {
-    let listViewDisplayed = true;
+    let listViewDisplayed = this.state.listViewDisplayed;
 
     if (nextProps.listViewDisplayed !== 'auto') {
       listViewDisplayed = nextProps.listViewDisplayed;


### PR DESCRIPTION
Previously when changing any unrelated prop, the list view would show up